### PR TITLE
auth setup: sign up and sign out

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,63 @@
+"use client";
+
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { authClient } from "@/lib/auth-client";
+import { useState } from "react";
 
 export default function Home() {
-  return <Button variant="link">Click me!</Button>;
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const session = authClient.useSession();
+
+  if (session.data?.user) {
+    return (
+      <div className="flex flex-col p-4 gap-y-4">
+        <p> Logged in as {session.data.user.name}</p>
+        <Button onClick={() => authClient.signOut()}>Sign out</Button>
+      </div>
+    );
+  }
+
+  const onSubmit = () => {
+    authClient.signUp.email(
+      {
+        email,
+        name,
+        password,
+      },
+      {
+        onSuccess: (ctx) => {
+          alert(ctx.response);
+        },
+        onError: (ctx) => {
+          alert(ctx.error.message);
+        },
+      },
+    );
+  };
+
+  return (
+    <div className="p-4 flex flex-col gap-y-4">
+      <Input
+        placeholder="name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Input
+        placeholder="email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <Input
+        placeholder="password"
+        value={password}
+        type="password"
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <Button onClick={onSubmit}>Create user</Button>
+    </div>
+  );
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,10 +1,14 @@
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import { db } from "@/db";
+import * as schema from "@/db/schema";
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg",
+    schema: {
+      ...schema,
+    },
   }),
   emailAndPassword: {
     enabled: true,


### PR DESCRIPTION
This pull request introduces user authentication functionality to the application. It includes updates to the `Home` page to support user sign-up and login/logout flows, as well as modifications to the authentication configuration to integrate database schema.

### User authentication functionality:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR1-R62): Added a user authentication flow to the `Home` page. This includes input fields for name, email, and password, a sign-up button, and conditional rendering based on the user's session state. Logged-in users can see their name and a sign-out button.

### Authentication configuration updates:

* [`src/lib/auth.ts`](diffhunk://#diff-486994d46df34c53636a706a1ca6a05bd8261ccde47463ea2c739af56f090b78R4-R11): Updated the `betterAuth` configuration to include the database schema from `@/db/schema`. This ensures that the authentication system integrates properly with the database.